### PR TITLE
`Sync`周りの挙動修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,9 +24,6 @@ tree = bot.tree
 async def on_ready():
     print(f"Logged in as {bot.user.name} ({bot.user.id})")
     print("------")
-    print("Syncing commands")
-    await tree.sync()
-    print("Synced commands")
 
 
 @tree.command(name="ping", description="ping! Pong!")

--- a/main.py
+++ b/main.py
@@ -16,13 +16,13 @@ intents = discord.Intents.all()
 intents.typing = False
 intents.presences = False
 
-client = discord.Client(intents=intents)
-tree = discord.app_commands.CommandTree(client)
+bot = commands.Bot(intents=intents, command_prefix="!")
+tree = bot.tree
 
 
-@client.event
+@bot.event
 async def on_ready():
-    print(f"Logged in as {client.user.name} ({client.user.id})")
+    print(f"Logged in as {bot.user.name} ({bot.user.id})")
     print("------")
     print("Syncing commands")
     await tree.sync()
@@ -70,4 +70,4 @@ async def add_white_list(interaction: discord.Integration, user: str):
     await interaction.response.send_message(f"Added {user} to whitelist log:{sub.stdout.decode()}", ephemeral=True)
 
 
-client.run(DISCORD_TOKEN)
+bot.run(DISCORD_TOKEN)

--- a/main.py
+++ b/main.py
@@ -31,11 +31,6 @@ async def on_ready():
 @tree.command(name="ping", description="ping! Pong!")
 async def hello(interaction: discord.Interaction):
     await interaction.response.send_message("Pong!", ephemeral=True)
-    print("sync")
-    await tree.sync(guild=discord.Object(id=911047487144484947))
-    print("synced")
-    await tree.sync()
-    print("super sync")
 
 
 # Umbra's sync command

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ intents.presences = False
 client = discord.Client(intents=intents)
 tree = discord.app_commands.CommandTree(client)
 
+
 @client.event
 async def on_ready():
     print(f"Logged in as {client.user.name} ({client.user.id})")
@@ -27,43 +28,46 @@ async def on_ready():
     await tree.sync()
     print("Synced commands")
 
-@tree.command(name = "ping", description="ping! Pong!")
+
+@tree.command(name="ping", description="ping! Pong!")
 async def hello(interaction: discord.Interaction):
     await interaction.response.send_message("Pong!", ephemeral=True)
     print("sync")
-    await tree.sync(guild=discord.Object(id = 911047487144484947))
+    await tree.sync(guild=discord.Object(id=911047487144484947))
     print("synced")
     await tree.sync()
     print("super sync")
 
 
-@tree.command(name = "sync", description="sync command")
+@tree.command(name="sync", description="sync command")
 async def sync(interaction: discord.Interaction):
     await interaction.response.send_message("Starting Sync", ephemeral=True)
     print("sync")
-    await tree.sync(guild=discord.Object(id = 911047487144484947))
+    await tree.sync(guild=discord.Object(id=911047487144484947))
     print("synced")
     await tree.sync()
     print("super sync")
 
-@tree.command(name = "free", description="show memory information")
+
+@tree.command(name="free", description="show memory information")
 async def memory(interaction: discord.Interaction):
     sub = subprocess.run(["free", "-h"], stdout=subprocess.PIPE)
     print(sub.stdout.decode())
     await interaction.response.send_message(sub.stdout.decode(), ephemeral=True)
 
 
-@tree.command(name = "avg", description="show load average")
+@tree.command(name="avg", description="show load average")
 async def memory(interaction: discord.Interaction):
     sub = subprocess.run(["cat", "/proc/loadavg"], stdout=subprocess.PIPE)
     print(sub.stdout.decode())
     await interaction.response.send_message(sub.stdout.decode(), ephemeral=True)
 
+
 @tree.command(name="add_whitelist")
 async def add_white_list(interaction: discord.Integration, user: str):
-    sub = subprocess.run(["docker", "exec minecraft_mc_1", "rcon-cli", "whitelist", "add", user], stdout=subprocess.PIPE)
+    sub = subprocess.run(["docker", "exec minecraft_mc_1", "rcon-cli", "whitelist", "add", user],
+                         stdout=subprocess.PIPE)
     await interaction.response.send_message(f"Added {user} to whitelist log:{sub.stdout.decode()}", ephemeral=True)
-    
 
 
 client.run(DISCORD_TOKEN)


### PR DESCRIPTION
- Format `main.py`
コードをPEP8に従いフォーマット
- Use `Bot` instead of `Client` in `main.py`
`Client`は一部機能が実装されてないうえ、`Bot`のほうが推奨されているので代わりにBotを使用
- Remove sync operation from `on_ready` event
`on_ready`と`setup_hook`での同期は423(Too Many Requests)を引き起こす可能性があるので
詳しくは[app-command-basics](https://about.abstractumbra.dev/discord.py/2023/01/30/app-command-basics.html#caveats)を参照
- Replace `sync` command with new command
`on_ready`での`sync`が無くなったことに伴い、同期を手動で行う必要があるので[unmbra's sync command](https://about.abstractumbra.dev/discord.py/2023/01/29/sync-command-example.html)を使用して同期コマンドを実装。基本的に`!sync *`しか使用しない。
